### PR TITLE
docs: reframe README around the mission + add English version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
 
-# 🕵️ Intel Briefing - AI 情报聚合引擎
+# 🕵️ Intel Briefing — 你的个人情报官
 
-**每天 5 分钟，掌握全球科技圈正在发生什么。**
+**中文** | [English](README_EN.md)
 
-从 12+ 数据源自动抓取、翻译、分析情报，生成一份中文日报。
+**别只是刷新闻。把每天的全球信号——包括你信息茧房之外的那些——变成「今天我该做什么」的答案。**
 
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white)](https://python.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
@@ -17,17 +17,28 @@
 
 ## 🤔 这是什么？
 
-一个**情报采集+分析引擎**，自动从全网科技信息源抓取数据，用 Gemini 翻译和摘要，生成一份结构化的中文报告。
+一套**个人情报系统**。它每天帮你做三件事：
+
+1. 📡 **抓情报** — 从 10+ 全球科技/商业信息源自动采集、翻译、摘要，生成一份中文日报。
+2. 🔭 **破茧房** — 用一个专门的「跨域雷达」主动塞给你科学、哲学、地缘、设计等**科技圈以外**的信号，刻意和上面的科技源零重叠，免得你越看越窄。
+3. 🚀 **找灵感** — 把上面两样喂给一个思维框架，提炼成一份**每日行动计划（Mission Plan）**，回答那个真正重要的问题：
+
+> 🧭 **今天做什么，能让自己变得更有价值？**
+> 而「有价值」不局限于你当前的赛道——跨越边界的认知，才是终极杠杆。
+
+**和普通新闻聚合器的区别**：聚合器给你「更多信息」；它给你「更宽的视野 + 一个可执行的答案」。
 
 **适合谁用？**
-- 想每天快速了解科技圈动态的开发者
+- 想每天快速了解全球动态、又怕陷进信息茧房的开发者
 - 做竞品分析、行业研究的产品经理
-- 想找灵感和机会的独立开发者 / 创业者
+- 想从每日信号里找灵感和机会的独立开发者 / 创作者
 
-## ✨ 功能概览
+---
 
-### 📊 情报日报
-从 12+ 数据源抓取最新信息，生成包含 7 大板块的中文日报：
+## ✨ 三层能力
+
+### 📊 第一层：情报日报
+从 10+ 数据源抓取最新信息，生成包含 7 大板块的中文日报：
 
 | 板块 | 数据源 | 你能看到什么 |
 |:--|:--|:--|
@@ -38,6 +49,73 @@
 | 💬 社区热点 | V2EX | 中文开发者社区在讨论什么 |
 | 🐦 社交热议 | X (Twitter) via Grok | Twitter 上的技术热话题 |
 | 📖 深度洞察 | HN Top Blogs, TechCrunch, MIT TR | AI 巨头工程博客全文分析 |
+
+### 🔭 第二层：Horizon —— 防信息茧房雷达
+日报覆盖的是科技 / AI / 商业垂类。但你的认知边界，不该被数据源的边界限制。
+
+Horizon 是一个独立的「跨域认知雷达」，**刻意只抓科技圈以外**的高质量信息源，覆盖 5 大领域、9 个源：
+
+| 领域 | 信息源 |
+|:--|:--|
+| 🔬 科学前沿 | Nature、Quanta Magazine |
+| 🧠 哲学人文 | Aeon (Essays / Philosophy) |
+| 🌍 地缘与经济 | Reuters、Geopolitical Futures |
+| 🔀 跨学科 | Nautilus、Aeon (Science) |
+| 🎨 设计美学 | Dezeen |
+
+它内置「领域多样性」逻辑——保证每个领域至少出一条，绝不让你被单一信息流淹没。
+
+```bash
+python scripts/horizon_report.py        # 单独跑一次跨域扫描
+```
+
+> 实现见 `src/sensors/horizon.py`。它是独立功能，**不混进日报**，而是作为「破茧」输入，喂给下面的 Mission Plan。
+
+### 🚀 第三层：Mission Plan —— 每日行动计划
+这是整个系统的落点。把「日报 + Horizon 跨域信号」交给一个**思维树（Tree of Thoughts）框架**，提炼成一份当日行动计划，分四个区：
+
+| 区域 | 是什么 |
+|:--|:--|
+| 🔴 核心区 (Strike Zone) | 直接能让你「更有价值」的信号 → 提炼出今日 **Top 1 必做** |
+| 🟡 探索区 (Exploration Zone) | 不直接相关、但有「跨域杠杆」潜力的信号 |
+| 🔭 地平线区 (Horizon Zone) | 来自科技圈以外的认知冲击，**强制非空**——这是防茧房的硬约束 |
+| ⚪ 监测区 (Watch Zone) | 暂不行动、但值得保持雷达的趋势 |
+
+框架定义在 `prompts/tot_mission_planner.md`（一个可直接喂给 LLM 的 prompt）。想让它贴合你自己的方向？复制 `prompts/commander_state.example.md` 填上你的身份和优先级即可。
+
+> ⚠️ Mission Plan 是 **prompt 驱动**的一步：你把当天的日报和 Horizon 结果连同这个 prompt 交给 LLM（Claude / Gemini 等），由它生成。不是一键脚本。
+
+---
+
+## 📸 长这样
+
+**① 每日情报日报（节选）**
+
+```markdown
+# 🌐 全球情报日报
+**日期:** 2026-05-27
+
+## 🛠️ 技术趋势
+### 1. [Language Models Need Sleep](https://arxiv.org/abs/...)
+📍 Hacker News | 🔥 84 points | 🕒 1 小时前
+
+## 📚 学术前沿
+### 1. MobileGym: A Verifiable Simulation Platform for Mobile GUI Agents
+👤 ... | 📅 2026-05-25
+```
+
+**② Mission Plan（结构示意）**
+
+```markdown
+# 🚀 Mission Plan [日期]
+
+> ⚡ 今日 Top 1：<最该立刻动手的一件事>（⏱️ 预计耗时 / 🎯 对我的价值）
+
+## 🔴 核心区     主线推进 / 能力杠杆 / 真诚表达 / 认知升级
+## 🟡 探索区     <信号> → "这可能和你有关，因为…"
+## 🔭 地平线区   <科技圈外的认知冲击>   ← 强制非空
+## ⚪ 监测区     <暂不行动、但保持关注的趋势>
+```
 
 ---
 
@@ -61,11 +139,12 @@ cp .env.example .env
 ### 3. 运行
 
 ```bash
-python cli.py              # 生成完整日报
-python cli.py --test       # 测试模式（每个源只抓 1 条）
+python cli.py                       # 生成完整日报
+python cli.py --test                # 测试模式（每个源只抓 1 条）
+python scripts/horizon_report.py    # 跑跨域 Horizon 扫描
 ```
 
-报告保存在 `reports/daily_briefings/` 目录下。
+日报保存在 `reports/daily_briefings/`。想要每日行动计划，把日报 + Horizon 结果连同 `prompts/tot_mission_planner.md` 交给你的 LLM 即可。
 
 ### 4. 代理配置（可选）
 
@@ -91,7 +170,7 @@ export HTTPS_PROXY=http://127.0.0.1:7890
 | `PRODUCTHUNT_TOKEN` | Product Hunt 数据 | 可选 | ✅ [免费申请](https://www.producthunt.com/v2/oauth/applications) |
 | `GEMINI_API_KEY` | Google Gemini (中文翻译+摘要) | 可选 | ✅ 免费额度充足 ([申请](https://aistudio.google.com/apikey)) |
 
-> ⚠️ **最低要求：拿到 `GITHUB_TOKEN` 就能跑基础日报。** 没有其他 Key 时对应功能会优雅降级（跳过而非崩溃）。
+> ⚠️ **最低要求：拿到 `GITHUB_TOKEN` 就能跑基础日报。** 没有其他 Key 时对应功能会优雅降级（跳过而非崩溃）。Horizon 雷达走公开 RSS，零 Key 即可运行。
 
 ---
 
@@ -99,8 +178,8 @@ export HTTPS_PROXY=http://127.0.0.1:7890
 
 > [!NOTE]
 > 数据是从两个地方抓的，你不用关心这个区别——日报里看到的内容都一样。
-> - 一批"老牌"信息源（HN、GitHub、36Kr、V2EX、WallStreetCN）走 `src/external/fetch_news.py`
-> - 其余每个源各有一个独立的"传感器"文件，放在 `src/sensors/` 里
+> - 一批「老牌」信息源（HN、GitHub、36Kr、V2EX、WallStreetCN）走 `src/external/fetch_news.py`
+> - 其余每个源各有一个独立的「传感器」文件，放在 `src/sensors/` 里
 >
 > 这是项目早期演进留下的两套写法，功能上都正常，未来会慢慢合并成一套。
 
@@ -120,7 +199,7 @@ Intel_Briefing/
 │   │   ├── techcrunch_rss.py   # TechCrunch RSS
 │   │   ├── mit_tech_review.py  # MIT Technology Review
 │   │   ├── x_grok_sensor.py    # X/Twitter via Grok API
-│   │   └── horizon.py          # 机会雷达 (独立功能，见下方 scripts/)
+│   │   └── horizon.py          # 🔭 Horizon 跨域雷达 (防信息茧房，见下方 scripts/)
 │   ├── utils/
 │   │   ├── gemini_translator.py # Gemini 中文翻译 + 摘要
 │   │   ├── generate_summaries.py # PWA 预烘焙摘要
@@ -128,8 +207,11 @@ Intel_Briefing/
 │   │   └── verifier.py         # 链接有效性验证
 │   └── external/
 │       └── fetch_news.py       # Tier 1: HN/GitHub/36Kr/V2EX/WS 聚合器
+├── prompts/                    # 🧠 分析框架 prompt 模板
+│   ├── tot_mission_planner.md  # Mission Plan 思维树框架
+│   └── commander_state.example.md # 个性化模板 (复制后填你的身份/优先级)
 ├── scripts/                    # 🧰 附带的小工具 (与日报独立)
-│   ├── horizon_report.py       # 机会雷达：扫描跨领域的新机会
+│   ├── horizon_report.py       # Horizon 雷达：扫描跨领域信号
 │   ├── condense_month.py       # 把一个月的日报浓缩成月报
 │   └── recurrence_scan.py      # 找出反复出现的热点话题
 ├── tests/                      # 30 tests (import/行为/降级)

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,295 @@
+<div align="center">
+
+# 🕵️ Intel Briefing — Your Personal Intelligence Officer
+
+[中文](README.md) | **English**
+
+**Don't just doomscroll. Turn each day's global signals — including the ones outside your filter bubble — into an answer to "what should I do today?"**
+
+[![Python 3.11+](https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white)](https://python.org)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Tests](https://img.shields.io/badge/Tests-30%20passed-brightgreen)](tests/)
+[![GitHub Stars](https://img.shields.io/github/stars/77AutumN/Intel_Briefing?style=social)](https://github.com/77AutumN/Intel_Briefing)
+
+</div>
+
+---
+
+## 🤔 What is this?
+
+A **personal intelligence system**. Every day it does three things for you:
+
+1. 📡 **Gather** — Automatically collect, translate, and summarize from 10+ global tech/business sources into a daily briefing.
+2. 🔭 **Break the bubble** — A dedicated "cross-domain radar" deliberately feeds you signals from *outside* tech — science, philosophy, geopolitics, design — with zero overlap with the tech sources above, so your view doesn't keep narrowing.
+3. 🚀 **Find ideas** — Feed both into a reasoning framework that distills them into a daily **Mission Plan**, answering the question that actually matters:
+
+> 🧭 **What can I do today to become more valuable?**
+> And "valuable" isn't confined to your current lane — cognition that crosses boundaries is the ultimate leverage.
+
+**How it differs from a plain news aggregator:** an aggregator gives you *more information*; this gives you *a wider field of view + one actionable answer*.
+
+**Who is it for?**
+- Developers who want a fast daily read on the world — without sliding into a filter bubble
+- Product managers doing competitive / industry research
+- Indie hackers / creators looking for inspiration and opportunities in the daily signal
+
+---
+
+## ✨ Three Layers
+
+### 📊 Layer 1: The Daily Briefing
+Pulls from 10+ sources into a 7-section briefing:
+
+| Section | Sources | What you get |
+|:--|:--|:--|
+| 🛠️ Tech Trends | Hacker News, GitHub Trending | What developers are talking about today |
+| 💰 Capital Flow | 36Kr, WallStreetCN | Who's raising, who's acquiring |
+| 📚 Research Frontier | ArXiv AI/ML, **HF Daily Papers** | Latest AI papers, ranked by community heat |
+| 🚀 Product Picks | Product Hunt | What launched today |
+| 💬 Community | V2EX | What the Chinese dev community is discussing |
+| 🐦 Social Buzz | X (Twitter) via Grok | Hot technical topics on Twitter |
+| 📖 Deep Insights | HN Top Blogs, TechCrunch, MIT TR | Full-text analysis of top engineering blogs |
+
+### 🔭 Layer 2: Horizon — the Anti-Filter-Bubble Radar
+The briefing covers the tech / AI / business vertical. But your cognitive boundary shouldn't be limited by the boundary of your data sources.
+
+Horizon is a standalone "cross-domain cognitive radar" that **deliberately pulls only from outside tech**, spanning 5 domains across 9 sources:
+
+| Domain | Sources |
+|:--|:--|
+| 🔬 Science | Nature, Quanta Magazine |
+| 🧠 Philosophy & Humanities | Aeon (Essays / Philosophy) |
+| 🌍 Geopolitics & Economics | Reuters, Geopolitical Futures |
+| 🔀 Cross-disciplinary | Nautilus, Aeon (Science) |
+| 🎨 Design & Aesthetics | Dezeen |
+
+It has built-in "domain diversity" logic — guaranteeing at least one item per domain, so you're never drowned in a single stream.
+
+```bash
+python scripts/horizon_report.py        # run a one-off cross-domain scan
+```
+
+> Implemented in `src/sensors/horizon.py`. It's a standalone feature — **it does not get mixed into the briefing**. Instead it serves as the "bubble-breaking" input feeding the Mission Plan below.
+
+### 🚀 Layer 3: Mission Plan — the Daily Action Plan
+This is where the whole system lands. It hands "briefing + Horizon cross-domain signals" to a **Tree of Thoughts (ToT) framework**, distilling them into a daily action plan with four zones:
+
+| Zone | What it is |
+|:--|:--|
+| 🔴 Strike Zone | Signals that directly make you "more valuable" → distilled into today's **Top 1 must-do** |
+| 🟡 Exploration Zone | Not directly relevant, but with "cross-domain leverage" potential |
+| 🔭 Horizon Zone | Cognitive jolts from outside tech, **must be non-empty** — the hard anti-bubble constraint |
+| ⚪ Watch Zone | Trends not worth acting on yet, but worth keeping on the radar |
+
+The framework lives in `prompts/tot_mission_planner.md` (a prompt you can feed straight to an LLM). Want it tailored to you? Copy `prompts/commander_state.example.md` and fill in your identity and priorities.
+
+> ⚠️ The Mission Plan is a **prompt-driven** step: you hand the day's briefing and Horizon results, together with this prompt, to an LLM (Claude / Gemini / etc.), which generates it. It is not a one-command script.
+
+---
+
+## 📸 What it looks like
+
+**① Daily briefing (excerpt)**
+
+```markdown
+# 🌐 Global Intel Briefing
+**Date:** 2026-05-27
+
+## 🛠️ Tech Trends
+### 1. [Language Models Need Sleep](https://arxiv.org/abs/...)
+📍 Hacker News | 🔥 84 points | 🕒 1 hour ago
+
+## 📚 Research Frontier
+### 1. MobileGym: A Verifiable Simulation Platform for Mobile GUI Agents
+👤 ... | 📅 2026-05-25
+```
+
+**② Mission Plan (structure)**
+
+```markdown
+# 🚀 Mission Plan [date]
+
+> ⚡ Today's Top 1: <the one thing to act on now> (⏱️ est. time / 🎯 value to me)
+
+## 🔴 Strike Zone        Main quest / leverage / authentic voice / knowledge edge
+## 🟡 Exploration Zone   <signal> → "this might matter to you, because…"
+## 🔭 Horizon Zone       <a cognitive jolt from outside tech>   ← must be non-empty
+## ⚪ Watch Zone         <trends to keep watching, no action yet>
+```
+
+---
+
+## 🚀 Quick Start
+
+### 1. Clone & install
+
+```bash
+git clone https://github.com/77AutumN/Intel_Briefing.git
+cd Intel_Briefing
+pip install -e .       # editable install (fixes all import paths)
+```
+
+### 2. Configure API keys
+
+```bash
+cp .env.example .env
+# edit .env and fill in your own API keys
+```
+
+### 3. Run
+
+```bash
+python cli.py                       # generate the full briefing
+python cli.py --test                # test mode (1 item per source)
+python scripts/horizon_report.py    # run the cross-domain Horizon scan
+```
+
+Briefings are saved under `reports/daily_briefings/`. For a daily action plan, hand the briefing + Horizon results, together with `prompts/tot_mission_planner.md`, to your LLM.
+
+### 4. Proxy (optional)
+
+```bash
+export HTTP_PROXY=http://127.0.0.1:7890
+export HTTPS_PROXY=http://127.0.0.1:7890
+```
+
+> [!IMPORTANT]
+> `httpx` does not support SOCKS proxies by default. If your proxy only exposes a SOCKS port, install:
+> ```bash
+> pip install httpx[socks]
+> ```
+
+---
+
+## 🔑 API Keys
+
+| Key | Purpose | Required? | Cost |
+|:--|:--|:--|:--|
+| `GITHUB_TOKEN` | GitHub Trending (GraphQL API) | **Required** | ✅ [free PAT](https://github.com/settings/tokens) |
+| `XAI_API_KEY` | Grok API (X/Twitter buzz + PH fallback) | Recommended | $25/mo free credit ([apply](https://console.x.ai/)) |
+| `PRODUCTHUNT_TOKEN` | Product Hunt data | Optional | ✅ [free](https://www.producthunt.com/v2/oauth/applications) |
+| `GEMINI_API_KEY` | Google Gemini (translation + summary) | Optional | ✅ generous free tier ([apply](https://aistudio.google.com/apikey)) |
+
+> ⚠️ **Minimum: with just `GITHUB_TOKEN` you can run a basic briefing.** Without the other keys, those features degrade gracefully (skipped, not crashed). Horizon uses public RSS — zero keys needed.
+
+---
+
+## 📁 Project Structure
+
+> [!NOTE]
+> Data is fetched from two places — you don't need to care about the distinction; what you see in the briefing is the same either way.
+> - A batch of "legacy" sources (HN, GitHub, 36Kr, V2EX, WallStreetCN) goes through `src/external/fetch_news.py`
+> - Every other source has its own standalone "sensor" file under `src/sensors/`
+>
+> This is two coding styles left over from the project's early evolution; both work fine, and they'll be merged over time.
+
+```
+Intel_Briefing/
+├── cli.py                      # 🎯 main entry
+├── pyproject.toml              # package config (pip install -e .)
+├── src/
+│   ├── config.py               # unified config (IntelConfig singleton)
+│   ├── intel_collector.py      # collector (concurrent scheduling + dedup)
+│   ├── report_generator.py     # report renderer (incl. anti-hallucination)
+│   ├── sensors/                # Tier 2: standalone source sensors
+│   │   ├── arxiv_ai.py         # ArXiv AI/ML papers
+│   │   ├── hf_daily_papers.py  # HuggingFace Daily Papers
+│   │   ├── hn_blogs.py         # top engineering blogs RSS (15 feeds + dynamic OPML)
+│   │   ├── product_hunt.py     # Product Hunt (incl. Grok fallback)
+│   │   ├── techcrunch_rss.py   # TechCrunch RSS
+│   │   ├── mit_tech_review.py  # MIT Technology Review
+│   │   ├── x_grok_sensor.py    # X/Twitter via Grok API
+│   │   └── horizon.py          # 🔭 Horizon cross-domain radar (anti-bubble, see scripts/)
+│   ├── utils/
+│   │   ├── gemini_translator.py # Gemini translation + summary
+│   │   ├── generate_summaries.py # PWA pre-baked summaries
+│   │   ├── jina_reader.py      # full-text extraction (incl. DDG fallback)
+│   │   └── verifier.py         # link validity check
+│   └── external/
+│       └── fetch_news.py       # Tier 1: HN/GitHub/36Kr/V2EX/WS aggregator
+├── prompts/                    # 🧠 analysis-framework prompt templates
+│   ├── tot_mission_planner.md  # Mission Plan Tree-of-Thoughts framework
+│   └── commander_state.example.md # personalization template (copy & fill in)
+├── scripts/                    # 🧰 bundled tools (independent of the briefing)
+│   ├── horizon_report.py       # Horizon radar: scan cross-domain signals
+│   ├── condense_month.py       # condense a month of briefings into a monthly report
+│   └── recurrence_scan.py      # surface recurring hot topics
+├── tests/                      # 30 tests (import/behavior/degradation)
+│   ├── test_import_smoke.py    # 12-module import check
+│   ├── test_anti_hallucination.py  # anti-hallucination behavior test
+│   ├── test_graceful_degradation.py # graceful degradation test
+│   └── test_core.py            # core functionality test
+├── reports/                    # 📄 generated reports (gitignored)
+└── .env.example                # API key template
+```
+
+---
+
+## ⚙️ Configuration
+
+All config is managed by the `IntelConfig` singleton in `src/config.py`. Priority: env var > `.env` > default.
+
+Key settings:
+
+| Variable | Default | Description |
+|:--|:--|:--|
+| `GEMINI_MODEL` | `gemini-2.0-flash` | Gemini model for translation/summary |
+| `XAI_MODEL` | `x-ai/grok-4-fast` | Grok API model |
+| `FETCH_TIMEOUT` | `15` | network request timeout (seconds) |
+| `LIMIT_PER_SOURCE` | `10` | max items fetched per source |
+| `CONTENT_TRUNCATE_LIMIT` | `3000` | content truncation length (chars) |
+
+---
+
+## 🧪 Tests
+
+```bash
+pip install -e .      # first time only
+pytest tests/ -v      # 30 tests, <1s
+```
+
+Three dimensions covered:
+- **Import Smoke**: all 12 modules import independently
+- **Anti-Hallucination**: guessed URLs from Grok fallback never enter the report as clickable links
+- **Graceful Degradation**: missing API keys or empty data never crash the system
+
+---
+
+## 🛡️ Anti-Hallucination
+
+When the Product Hunt API is unavailable, the system falls back to Grok-inferred product data. The URLs it produces are **guessed slugs**, not real links.
+
+**How it's handled:**
+- Grok-fallback products are tagged `⚠️ Link unverified (AI-inferred)` in the report
+- They are not rendered as clickable markdown links
+- A Google search verification link is provided for manual confirmation
+
+---
+
+## 🤖 GitHub Actions
+
+The project ships with `.github/workflows/daily-report.yml`. Once Secrets are configured, it generates a briefing daily at UTC 23:51 (Beijing 07:51).
+
+> **Optional delivery to a frontend repo:** if you have your own PWA / frontend repo, set the repo variable `PWA_REPO` (e.g. `your-name/your-pwa-repo`) and the Secret `PWA_DEPLOY_TOKEN`, and the workflow will push the briefing there automatically; leave them unset to skip that step without affecting briefing generation.
+
+---
+
+## 📝 Known Limitations
+
+- `fetch_news.py` and `sensors/` are two coexisting collection paths (consolidation planned, Phase 2)
+- Sensor `print()` output isn't unified into `logging` yet (Phase 2)
+- Some sensors may hit GBK encoding issues when run standalone on Windows (no issue on Ubuntu CI)
+
+---
+
+## 📄 License
+
+MIT — use it however you like, no need to tell me if you change it.
+
+---
+
+<div align="center">
+
+**If you find it useful, a ⭐ is the biggest support.**
+
+</div>


### PR DESCRIPTION
## 为什么

之前 README 把项目写成「科技新闻聚合器」，但它真正的内核是一套**个人情报系统**——三步闭环：① 每日情报 → ② Horizon 跨域雷达**主动打破信息茧房** → ③ 用 ToT 框架提炼成每日 **Mission Plan**（「今天做什么能让自己更有价值」）。README 只讲了第 1 步，把灵魂藏起来了。这轮重新定位叙事。

## 改了什么

- **重写定位与开头**：新 tagline + 「这是什么」改成讲清三步闭环和北极星
- **新增两个重点板块**：🔭 Horizon 防信息茧房雷达（5 领域 9 源）、🚀 Mission Plan 每日行动计划（四区框架，地平线区强制非空 = 防茧房硬约束）
- **新增「长这样」样例**：日报片段 + Mission Plan 四区结构示意
- **新建 `README_EN.md`**：完整英文镜像，两份顶部互加语言切换链接

## 准确性 & 边界

- Horizon 如实写成**独立脚本**（不混入日报管线）；Mission Plan 如实写成 **prompt 驱动**的一步（非一键脚本）
- **未改任何代码**；未引用私有品牌/目录

## 验证

- 去个人化 grep → 零命中
- README 引用的每个文件路径均真实存在
- `python scripts/horizon_report.py --limit 3` 跑通：9 源、领域多样化输出

🤖 Generated with [Claude Code](https://claude.com/claude-code)